### PR TITLE
Fixed: Assignment to constant variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const proxy_check = p => {
 
     return new Promise((resolve, reject) => {
 
-        const proxy = {
+        let proxy = {
             host: '',
             port: 0,
             proxyAuth: ''


### PR DESCRIPTION
An error would throw because the proxy constant object was being reassigned on line 12/28.